### PR TITLE
Fix build related problem

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -48,5 +48,11 @@ In addition the following Linux software packages are required:
 
 ## Building
 
+Run submodule updates
+```
+git submodule init
+git submodule update
+```
+
 That is it. The everything else is referenced from the gradle files.
 Launch Android Studio, open the project, and build it. It should work.

--- a/resources.makefile
+++ b/resources.makefile
@@ -131,7 +131,7 @@ resources/nonfree/raw_$$(image_id).png:
 		-H "Accept: application/json" \
 		-H "Authorization: Bearer $$$$( cat ./flaticon-token )" \
 		--output "$$@" \
-		"https://api.flaticon.com/v2/item/icon/download/$$(call get_field,1,$(1))"
+		"https://api.flaticon.com/v3/item/icon/download/$$(call get_field,1,$(1))"
 endif
 
 resources/nonfree/$$(call get_field,2,$(1)).png: resources/nonfree/raw_$$(image_id).png resources/nonfree/$$(call get_field,2,$(1)).marker


### PR DESCRIPTION
This PR fixes some build related problem:
1. v2 flaticon api does not work. V3 works correctly.
2. the folder `app/src/main/res/drawable-xxxdhpi/` is required for the build to run properly
3. add documentation about building submodule