### PR TITLE
Add extra login headers for hass ingress service

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -123,13 +123,16 @@ dependencies {
     implementation "androidx.camera:camera-lifecycle:$camerax_version"
     implementation "androidx.camera:camera-view:$camerax_version"
 
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     implementation 'androidx.core:core-ktx:1.10.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
+
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.json:json:20230618'
+
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
     implementation project(':zxing-cpp')
 }

--- a/app/src/androidTest/java/eu/pkgsoftware/babybuddywidgets/TestTokenEncryptionV1.kt
+++ b/app/src/androidTest/java/eu/pkgsoftware/babybuddywidgets/TestTokenEncryptionV1.kt
@@ -1,0 +1,36 @@
+package eu.pkgsoftware.babybuddywidgets
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+
+
+import eu.pkgsoftware.babybuddywidgets.test.R;
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+
+@RunWith(AndroidJUnit4::class)
+class TestTokenEncryptionV1 {
+    @Test
+    fun testDecryptionOfV1Settings() {
+        val inst = InstrumentationRegistry.getInstrumentation()
+        val inputStream = inst.context.resources.openRawResource(R.raw.settings_v1);
+
+        val adapter = object : CredStore.SettingsFileOpener {
+            override fun openReadStream(): InputStream {
+                return inputStream
+            }
+
+            override fun openWriteStream(): OutputStream {
+                throw IOException("Not implemented")
+            }
+
+        }
+
+        val credStore = CredStore(adapter, "0.0");
+        Assert.assertEquals(credStore.appToken, "97aa51ef1e60ea733cc7ede37c1e65376e9f0b45")
+    }
+}

--- a/app/src/androidTest/res/raw/settings_v1
+++ b/app/src/androidTest/res/raw/settings_v1
@@ -1,0 +1,21 @@
+#
+#Mon Jun 19 22:29:07 GMT+02:00 2023
+last_used_amount=null
+notes_diaper_andrea-lloyd=F\:
+salt=e0O2E9HN/XXBH9Etd49CBHEu4N6bB9MXwyigCtuYHGI\=\n
+notes_virttimer_17_53=F\:
+notes_virttimer_17_52=F\:
+notes_virttimer_17_51=F\:
+stored_version=2.1.0a
+selected_child=bernhard-lloyd
+token=H8txMl4GZo5ehrdt7rnY4sMclkqFL2m+nKQgKRS0qZbTlN/ivbA1a5cRcQPDvgcL\n
+notes_virttimer_1_5=F\:
+notes_virttimer_1_4=F\:
+notes_virttimer_1_3=F\:
+notes_diaper_bernhard-lloyd=F\:
+tutorial_parameters=aGVscF9oaW50\:MQ\=\=\n
+notes_diaper_peter-lloyd=F\:
+server=http\://192.168.0.10\:8888/
+notes_virttimer_2_8=F\:
+notes_virttimer_2_7=F\:
+notes_virttimer_2_6=F\:

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/CredStore.java
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/CredStore.java
@@ -13,8 +13,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -23,11 +21,6 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.regex.Pattern;
-
-import javax.crypto.Cipher;
-import javax.crypto.SecretKey;
-import javax.crypto.spec.IvParameterSpec;
-import javax.crypto.spec.SecretKeySpec;
 
 import androidx.annotation.NonNull;
 
@@ -326,12 +319,18 @@ public class CredStore extends CredStoreEncryptionEngine {
         return stringToStringMap(encodedMap);
     }
 
-    public void setAuthCookies(Map<String, String> cookies) {
-        if (cookies.size() == 0) {
+    public void storeAuthCookies(Map<String, String> cookies) {
+        if ((cookies == null) || (cookies.size() == 0)) {
             encryptedCookies = null;
         } else {
             encryptedCookies = encryptMessage(stringMapToString(cookies));
         }
         storePrefs();
+    }
+
+    public void clearLoginData() {
+        storeAppToken(null);
+        storeAuthCookies(null);
+        clearNotes();
     }
 }

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/CredStore.java
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/CredStore.java
@@ -169,11 +169,11 @@ public class CredStore extends CredStoreEncryptionEngine {
         StringBuilder result = new StringBuilder();
         for (Map.Entry<String, String> e : m.entrySet()) {
             String k = new String(
-                Base64.encode(e.getKey().getBytes(StandardCharsets.UTF_8), Base64.DEFAULT),
+                Base64.encode(e.getKey().getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP),
                 StandardCharsets.UTF_8
             );
             String v = new String(
-                Base64.encode(e.getValue().getBytes(StandardCharsets.UTF_8), Base64.DEFAULT),
+                Base64.encode(e.getValue().getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP),
                 StandardCharsets.UTF_8
             );
             result.append(k.trim()).append(":").append(v.trim()).append("\n");
@@ -190,10 +190,10 @@ public class CredStore extends CredStoreEncryptionEngine {
             }
 
             String key = new String(
-                Base64.decode(assignmentParts[0].trim(), Base64.DEFAULT), StandardCharsets.UTF_8
+                Base64.decode(assignmentParts[0].trim(), Base64.NO_WRAP), StandardCharsets.UTF_8
             );
             String value = new String(
-                Base64.decode(assignmentParts[1].trim(), Base64.DEFAULT), StandardCharsets.UTF_8
+                Base64.decode(assignmentParts[1].trim(), Base64.NO_WRAP), StandardCharsets.UTF_8
             );
             result.put(key, value);
         }

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/CredStore.java
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/CredStore.java
@@ -76,6 +76,7 @@ public class CredStore extends CredStoreEncryptionEngine {
 
     private String serverUrl;
     private String encryptedToken;
+    private String encryptedCookies = null;
     private Map<String, Notes> notesAssignments = new HashMap<String, Notes>();
     private Double lastUsedAmount = null;
     private Map<String, Integer> tutorialParameters = new HashMap<>();
@@ -112,6 +113,7 @@ public class CredStore extends CredStoreEncryptionEngine {
             }
 
             encryptedToken = props.getProperty("token");
+            encryptedCookies = props.getProperty("cookies", null);
 
             storedVersion = props.getProperty("stored_version", "-1");
 
@@ -214,6 +216,9 @@ public class CredStore extends CredStoreEncryptionEngine {
         if (encryptedToken != null) {
             props.setProperty("token", encryptedToken);
         }
+        if (encryptedCookies != null) {
+            props.setProperty("cookies", encryptedCookies);
+        }
 
         props.put("stored_version", storedVersion);
 
@@ -311,5 +316,22 @@ public class CredStore extends CredStoreEncryptionEngine {
 
     public boolean isStoredVersionOutdated() {
         return !CURRENT_VERSION.equals(storedVersion);
+    }
+
+    public Map<String, String> getAuthCookies() {
+        String encodedMap = decryptMessage(encryptedCookies);
+        if (encodedMap == null) {
+            return new HashMap<>();
+        }
+        return stringToStringMap(encodedMap);
+    }
+
+    public void setAuthCookies(Map<String, String> cookies) {
+        if (cookies.size() == 0) {
+            encryptedCookies = null;
+        } else {
+            encryptedCookies = encryptMessage(stringMapToString(cookies));
+        }
+        storePrefs();
     }
 }

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/CredStoreEncryptionEngine.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/CredStoreEncryptionEngine.kt
@@ -1,0 +1,83 @@
+package eu.pkgsoftware.babybuddywidgets
+
+import android.util.Base64
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.SecretKey
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+open class CredStoreEncryptionEngine {
+    private val ENCRYPTION_STRING =
+        "gK,8kwXJZRmL6/yz&Dp;tr5&Muk,A;h,VGeb\$qN-Gid3xLW&a/Xi0YOomVpQVAiFn:hP$8dbIX;L*v*cie&Tnkf+obFEN;a+DTmrILQO6CkY.oOV25dBjpXbep%qAu1bnbeS3A-zn%m"
+
+    fun generateNewSalt(): String {
+        val rnd = ByteArray(32)
+        SecureRandom().nextBytes(rnd)
+        return Base64.encodeToString(rnd, Base64.DEFAULT)
+    }
+
+    protected var SALT: String = generateNewSalt()
+
+    protected fun encryptMessage(message: String?): String? {
+        try {
+            return if (message == null) {
+                null
+            } else {
+                val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+                val rawKey: ByteArray =
+                    (SALT + ":::::" + ENCRYPTION_STRING).toByteArray(
+                        StandardCharsets.ISO_8859_1
+                    )
+                val md5Key = MessageDigest.getInstance("MD5").digest(rawKey)
+                val ivGen = MessageDigest.getInstance("MD5").digest(
+                    (String(
+                        md5Key,
+                        StandardCharsets.ISO_8859_1
+                    ) + ":::::" + SALT).toByteArray(
+                        StandardCharsets.UTF_8
+                    )
+                )
+                val key: SecretKey = SecretKeySpec(md5Key, "AES")
+                cipher.init(Cipher.ENCRYPT_MODE, key, IvParameterSpec(ivGen))
+                val encoded = cipher.doFinal(message.toByteArray(StandardCharsets.ISO_8859_1))
+                Base64.encodeToString(encoded, Base64.DEFAULT)
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+        return null
+    }
+
+    protected fun decryptMessage(encrypted: String?): String? {
+        try {
+            return if (encrypted == null) {
+                null
+            } else {
+                val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+                val rawKey: ByteArray =
+                    (SALT + ":::::" + ENCRYPTION_STRING).toByteArray(
+                        StandardCharsets.ISO_8859_1
+                    )
+                val md5Key = MessageDigest.getInstance("MD5").digest(rawKey)
+                val ivGen = MessageDigest.getInstance("MD5").digest(
+                    (String(
+                        md5Key,
+                        StandardCharsets.ISO_8859_1
+                    ) + ":::::" + SALT).toByteArray(
+                        StandardCharsets.UTF_8
+                    )
+                )
+                val key: SecretKey = SecretKeySpec(md5Key, "AES")
+                cipher.init(Cipher.DECRYPT_MODE, key, IvParameterSpec(ivGen))
+                val decoded = cipher.doFinal(Base64.decode(encrypted, Base64.DEFAULT))
+                String(decoded, StandardCharsets.ISO_8859_1)
+            }
+        } catch (e: java.lang.Exception) {
+            e.printStackTrace()
+        }
+        return null
+    }
+}

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/LoggedInFragment.java
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/LoggedInFragment.java
@@ -157,8 +157,7 @@ public class LoggedInFragment extends BaseFragment {
     }
 
     private void logout() {
-        credStore.storeAppToken(null);
-        credStore.clearNotes();
+        credStore.clearLoginData();
         Navigation.findNavController(getView()).navigate(R.id.logoutOperation);
     }
 

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/login/LoginData.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/login/LoginData.kt
@@ -5,9 +5,25 @@ import org.json.JSONObject
 
 class InvalidQRCodeException() : Exception("Invalid QR Code") {}
 
-class LoginData(val url: String, val token: String) {
+class LoginData(val url: String, val token: String, val cookies: Map<String, String>) {
     companion object {
         fun fromQrcodeJSON(qrcode: String): LoginData {
+            fun objectToStringMap(o: JSONObject?): Map<String, String> {
+                if (o == null) {
+                    return mapOf()
+                }
+
+                val result = mutableMapOf<String, String>()
+                for (key in o.keys()) {
+                    val value = o.get(key)
+                    if (value is String) {
+                        result[key] = value
+                    }
+                }
+                return result
+            }
+
+
             if (!qrcode.startsWith("BABYBUDDY-LOGIN:")) {
                 throw InvalidQRCodeException();
             }
@@ -16,10 +32,12 @@ class LoginData(val url: String, val token: String) {
                 val json = JSONObject(jsonPayload)
                 val url = json.getString("url")
                 val token = json.getString("api_key")
-                return LoginData(url, token)
+                val cookies = objectToStringMap(json.optJSONObject("session_cookies"))
+                return LoginData(url, token, cookies)
             } catch (e: JSONException) {
                 throw InvalidQRCodeException();
             }
         }
+
     }
 }

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/login/QRCodeLoginFragment.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/login/QRCodeLoginFragment.kt
@@ -225,7 +225,7 @@ class QRCodeLoginFragment : BaseFragment() {
 
                     override fun failed(s: String) {
                         progressDialog.hide()
-                        credStore.storeAppToken(null)
+                        credStore.clearLoginData()
                         binding.qrcodeCancelButton.performClick()
                         showError(true, "Login failed", s)
                     }

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/login/QRCodeLoginFragment.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/login/QRCodeLoginFragment.kt
@@ -215,6 +215,7 @@ class QRCodeLoginFragment : BaseFragment() {
                 val credStore = mainActivity.credStore;
                 credStore.storeServerUrl(loginData.url)
                 credStore.storeAppToken(loginData.token)
+                credStore.storeAuthCookies(loginData.cookies)
 
                 Utils(mainActivity).testLoginToken(object : Promise<Any, String> {
                     override fun succeeded(s: Any?) {

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/networking/BabyBuddyClient.java
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/networking/BabyBuddyClient.java
@@ -113,7 +113,7 @@ public class BabyBuddyClient extends StreamReader {
     }
 
     public static class QueryValues {
-        public HashMap<String, String> queryValues = new HashMap<String, String>();
+        public HashMap<String, String> queryValues = new HashMap<>();
 
         public QueryValues add(String name, String value) {
             queryValues.put(name, value);
@@ -137,6 +137,19 @@ public class BabyBuddyClient extends StreamReader {
                 result.append(e.getKey());
                 result.append("=");
                 result.append(urlencode(e.getValue()));
+            }
+            return result.toString();
+        }
+
+        public String toCookiesString() {
+            StringBuilder result = new StringBuilder("");
+            for (Map.Entry<String, String> e : queryValues.entrySet()) {
+                if (result.length() > 0) {
+                    result.append("; ");
+                }
+                result.append(e.getKey());
+                result.append("=");
+                result.append(e.getValue());
             }
             return result.toString();
         }
@@ -503,6 +516,13 @@ public class BabyBuddyClient extends StreamReader {
         HttpURLConnection con = (HttpURLConnection) pathToUrl(path).openConnection();
         String token = credStore.getAppToken();
         con.setRequestProperty("Authorization", "Token " + token);
+
+        QueryValues qValues = new QueryValues();
+        for (Map.Entry<String, String> entry : credStore.getAuthCookies().entrySet()) {
+            qValues.add(entry.getKey(), entry.getValue());
+        }
+        con.setRequestProperty("Cookie", qValues.toCookiesString());
+
         con.setDoInput(true);
         return con;
     }

--- a/app/src/test/java/eu/pkgsoftware/babybuddywidgets/login/LoginDataTest.kt
+++ b/app/src/test/java/eu/pkgsoftware/babybuddywidgets/login/LoginDataTest.kt
@@ -1,0 +1,39 @@
+package eu.pkgsoftware.babybuddywidgets.login
+
+import org.junit.Assert
+import org.junit.Test
+
+class LoginDataTest {
+    val classLoader = this.javaClass.classLoader!!
+
+    @Test
+    fun testLoginData_v1_1() {
+        val resourceUrl = classLoader.getResource("raw/login_data_v1.json")
+        val data = LoginData.fromQrcodeJSON(resourceUrl.readText())
+
+        Assert.assertEquals(data.url, "http://example.com/babybuddy/")
+        Assert.assertEquals(data.token, "abcdefabcdefabcdefacbdefabcdefbaadf00d55")
+        Assert.assertEquals(data.cookies.size, 0)
+    }
+
+    @Test
+    fun testLoginData_v2_1() {
+        val resourceUrl = classLoader.getResource("raw/login_data_v2-1.json")
+        val data = LoginData.fromQrcodeJSON(resourceUrl.readText())
+
+        Assert.assertEquals(data.url, "http://example.com/api/hassio_ingress/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA--Xs/")
+        Assert.assertEquals(data.token, "abcdefabcdefabcdefacbdefabcdefbaadf00d55")
+        Assert.assertEquals(data.cookies.size, 1)
+        Assert.assertEquals(data.cookies["ingress_session"], "abcdefabcdefabcdefacbdefabcdefbaadf00dabcdefabcdefabcdefacbdefabcdefbaadf00dabcdefabcdefabcdefacbdefabcdefbaadf00dabcdefabcdefab")
+    }
+
+    @Test
+    fun testLoginData_v2_2() {
+        val resourceUrl = classLoader.getResource("raw/login_data_v2-2.json")
+        val data = LoginData.fromQrcodeJSON(resourceUrl.readText())
+
+        Assert.assertEquals(data.url, "http://example.com/api/hassio_ingress/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA--Xs/")
+        Assert.assertEquals(data.token, "abcdefabcdefabcdefacbdefabcdefbaadf00d55")
+        Assert.assertEquals(data.cookies.size, 0)
+    }
+}

--- a/app/src/test/resources/raw/login_data_v1.json
+++ b/app/src/test/resources/raw/login_data_v1.json
@@ -1,0 +1,4 @@
+BABYBUDDY-LOGIN:{
+  "url": "http://example.com/babybuddy/",
+  "api_key": "abcdefabcdefabcdefacbdefabcdefbaadf00d55"
+}

--- a/app/src/test/resources/raw/login_data_v2-1.json
+++ b/app/src/test/resources/raw/login_data_v2-1.json
@@ -1,0 +1,7 @@
+BABYBUDDY-LOGIN:{
+  "url": "http://example.com/api/hassio_ingress/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA--Xs/",
+  "api_key": "abcdefabcdefabcdefacbdefabcdefbaadf00d55",
+  "session_cookies": {
+    "ingress_session": "abcdefabcdefabcdefacbdefabcdefbaadf00dabcdefabcdefabcdefacbdefabcdefbaadf00dabcdefabcdefabcdefacbdefabcdefbaadf00dabcdefabcdefab"
+  }
+}

--- a/app/src/test/resources/raw/login_data_v2-2.json
+++ b/app/src/test/resources/raw/login_data_v2-2.json
@@ -1,0 +1,3 @@
+BABYBUDDY-LOGIN:{"url": "http://example.com/api/hassio_ingress/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA--Xs/",
+  "api_key": "abcdefabcdefabcdefacbdefabcdefbaadf00d55",
+  "session_cookies": {}}


### PR DESCRIPTION
Issue #21
Issue https://github.com/OttPeterR/addon-babybuddy/issues/47

Caches the `ingress_session` key from homeassistant to allow logging in to babybuddy hosted behind the ingress-service.

## Extra test

- [x] Test if this still works when configuring a default-login user through the babybuddy-addon (I think it should)