### PR TITLE
Add debug allowing to debug server <-> client communication in production builds

### DIFF
--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/LoggedInFragment.java
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/LoggedInFragment.java
@@ -172,6 +172,9 @@ public class LoggedInFragment extends BaseFragment {
         if (item.getItemId() == R.id.aboutPageMenuItem) {
             Navigation.findNavController(getView()).navigate(R.id.global_aboutFragment);
         }
+        if (item.getItemId() == R.id.exportDebugLogsMenuButton) {
+            Navigation.findNavController(getView()).navigate(R.id.action_global_debugLogDisplay);
+        }
         return false;
     }
 

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/LoggedInFragment.java
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/LoggedInFragment.java
@@ -21,6 +21,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import androidx.viewpager2.widget.ViewPager2;
 import eu.pkgsoftware.babybuddywidgets.databinding.BabyManagerBinding;
 import eu.pkgsoftware.babybuddywidgets.databinding.LoggedInFragmentBinding;
+import eu.pkgsoftware.babybuddywidgets.debugging.GlobalDebugObject;
 import eu.pkgsoftware.babybuddywidgets.networking.BabyBuddyClient;
 import eu.pkgsoftware.babybuddywidgets.networking.ChildrenStateTracker;
 
@@ -154,6 +155,7 @@ public class LoggedInFragment extends BaseFragment {
     @Override
     public void onCreateOptionsMenu(@NonNull Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.loggedin_menu, menu);
+        menu.findItem(R.id.exportDebugLogsMenuItem).setVisible(GlobalDebugObject.getENABLED());
     }
 
     private void logout() {
@@ -172,7 +174,7 @@ public class LoggedInFragment extends BaseFragment {
         if (item.getItemId() == R.id.aboutPageMenuItem) {
             Navigation.findNavController(getView()).navigate(R.id.global_aboutFragment);
         }
-        if (item.getItemId() == R.id.exportDebugLogsMenuButton) {
+        if (item.getItemId() == R.id.exportDebugLogsMenuItem) {
             Navigation.findNavController(getView()).navigate(R.id.action_global_debugLogDisplay);
         }
         return false;

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/debugging/DebugLogDisplay.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/debugging/DebugLogDisplay.kt
@@ -1,0 +1,46 @@
+package eu.pkgsoftware.babybuddywidgets.debugging
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import eu.pkgsoftware.babybuddywidgets.R
+import eu.pkgsoftware.babybuddywidgets.databinding.FragmentDebugLogDisplayBinding
+
+class DebugLogDisplay : Fragment() {
+    lateinit var fragment: FragmentDebugLogDisplayBinding
+
+    override fun onResume() {
+        super.onResume()
+
+        val stringBuilder = StringBuilder(16000)
+        for (line in GlobalDebugObject.getLog()) {
+            stringBuilder.append(line.trim())
+            stringBuilder.append("\n<EOL>\n")
+        }
+        fragment.debugTextArea.setText(stringBuilder)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        fragment = FragmentDebugLogDisplayBinding.inflate(inflater)
+
+        fragment.copyToClipboardButton.setOnClickListener {
+            val clipboard = requireActivity().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            clipboard.setPrimaryClip(ClipData.newPlainText(
+                "BabyBuddy Debug Data", fragment.debugTextArea.text
+            ))
+
+            Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
+        }
+
+        return fragment.root
+    }
+}

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/debugging/DebugLogDisplay.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/debugging/DebugLogDisplay.kt
@@ -9,10 +9,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import eu.pkgsoftware.babybuddywidgets.BaseFragment
 import eu.pkgsoftware.babybuddywidgets.R
 import eu.pkgsoftware.babybuddywidgets.databinding.FragmentDebugLogDisplayBinding
 
-class DebugLogDisplay : Fragment() {
+class DebugLogDisplay : BaseFragment() {
     lateinit var fragment: FragmentDebugLogDisplayBinding
 
     override fun onResume() {
@@ -24,6 +25,8 @@ class DebugLogDisplay : Fragment() {
             stringBuilder.append("\n<EOL>\n")
         }
         fragment.debugTextArea.setText(stringBuilder)
+
+        mainActivity.setTitle(getString(R.string.export_debug_logs_title))
     }
 
     override fun onCreateView(

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/debugging/GlobalDebugObject.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/debugging/GlobalDebugObject.kt
@@ -1,0 +1,38 @@
+package eu.pkgsoftware.babybuddywidgets.debugging
+
+import android.util.Log
+
+class GlobalDebugObject {
+    companion object {
+        val ENABLED = true
+        val DO_PRINT = true
+        val LOG_FILE_MESSAGE_LIMIT = 10000
+
+        val LOCK = Object()
+
+        private val log = mutableListOf<String>()
+
+        @JvmStatic
+        fun log(msg: String) {
+            if (!ENABLED) return
+            synchronized(LOCK) {
+                while (log.size > LOG_FILE_MESSAGE_LIMIT) {
+                    log.removeAt(0)
+                }
+                if (DO_PRINT) {
+                    Log.println(Log.DEBUG, "GlobalDebugObject.log", msg)
+                }
+                log.add(msg)
+            }
+        }
+
+        @JvmStatic
+        fun getLog(): List<String> {
+            if (!ENABLED) return listOf()
+            val result = synchronized(LOCK) {
+                log.toList()
+            }
+            return result
+        }
+    }
+}

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/debugging/GlobalDebugObject.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/debugging/GlobalDebugObject.kt
@@ -4,8 +4,11 @@ import android.util.Log
 
 class GlobalDebugObject {
     companion object {
+        @JvmStatic
         val ENABLED = true
+        @JvmStatic
         val DO_PRINT = true
+        @JvmStatic
         val LOG_FILE_MESSAGE_LIMIT = 10000
 
         val LOCK = Object()

--- a/app/src/main/res/layout/fragment_debug_log_display.xml
+++ b/app/src/main/res/layout/fragment_debug_log_display.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".debugging.DebugLogDisplay">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginBottom="8dp"
+        app:layout_constraintBottom_toTopOf="@+id/copyToClipboardButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <EditText
+            android:id="@+id/debugTextArea"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ems="10"
+            android:enabled="false"
+            android:fontFamily="monospace"
+            android:gravity="start|top"
+            android:inputType="textMultiLine"
+            android:textAlignment="viewStart"
+            android:textColor="#000000"
+            android:textIsSelectable="true"
+            android:textSize="12sp" />
+    </ScrollView>
+
+    <Button
+        android:id="@+id/copyToClipboardButton"
+        android:layout_width="match_parent"
+        android:layout_height="54dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
+        android:text="@string/export_debug_logs_menu_item_copy_to_clipboard"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/loggedin_menu.xml
+++ b/app/src/main/res/menu/loggedin_menu.xml
@@ -13,6 +13,6 @@
         android:id="@+id/aboutPageMenuItem"
         android:title="@string/about_page_title" />
     <item
-        android:id="@+id/exportDebugLogsMenuButton"
+        android:id="@+id/exportDebugLogsMenuItem"
         android:title="@string/export_debug_logs_menu_item" />
 </menu>

--- a/app/src/main/res/menu/loggedin_menu.xml
+++ b/app/src/main/res/menu/loggedin_menu.xml
@@ -12,4 +12,7 @@
     <item
         android:id="@+id/aboutPageMenuItem"
         android:title="@string/about_page_title" />
+    <item
+        android:id="@+id/exportDebugLogsMenuButton"
+        android:title="@string/export_debug_logs_menu_item" />
 </menu>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -70,4 +70,9 @@
             app:argType="boolean"
             android:defaultValue="false" />
     </fragment>
+    <fragment
+        android:id="@+id/debugLogDisplay"
+        android:name="eu.pkgsoftware.babybuddywidgets.debugging.DebugLogDisplay"
+        android:label="fragment_debug_log_display"
+        tools:layout="@layout/fragment_debug_log_display" /><action android:id="@+id/action_global_debugLogDisplay" app:destination="@id/debugLogDisplay"/>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,6 +136,7 @@
     </string>
 
     <!-- Debugging -->
+    <string name="export_debug_logs_title">Export Debug Logs</string>
     <string name="export_debug_logs_menu_item">Export Debug Logs</string>
     <string name="export_debug_logs_menu_item_copy_to_clipboard">Copy to clipboard</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,8 +101,6 @@
     </string>
     <string name="history_delete_question_delete_button">Delete</string>
     <string name="history_delete_question_cancel_button">Cancel</string>
-    <!-- TODO: Remove or change this placeholder text -->
-    <string name="hello_blank_fragment">Hello blank fragment</string>
 
     <!-- QR Code Login -->
     <string name="login_qrcode_camera_access_needed_dialog_title">Camera access needed</string>
@@ -136,4 +134,8 @@
         Only the timers that are supported by the app are shown now. Timer controls and manual timer
         associations of timers with activities were removed.
     </string>
+
+    <!-- Debugging -->
+    <string name="export_debug_logs_menu_item">Export Debug Logs</string>
+    <string name="export_debug_logs_menu_item_copy_to_clipboard">Copy to clipboard</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Note: Disabled by default, can be enabled in the new `GlobalDebugObject`

![image](https://github.com/MrApplejuice/BabyBuddyAndroid/assets/542105/40167468-8aef-40d0-97c8-f7aaa53ffaee)

![image](https://github.com/MrApplejuice/BabyBuddyAndroid/assets/542105/d6307b53-f347-4297-9e4d-45f848aaa451)
