### PR TITLE
Open soft keyboard when starting a note

### DIFF
--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
@@ -1,8 +1,10 @@
 package eu.pkgsoftware.babybuddywidgets.timers
 
+import android.content.Context
 import android.os.Handler
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.Button
@@ -76,6 +78,7 @@ abstract class LoggingControls(val childId: Int) {
 
     open fun updateVisuals() {}
     open fun postInit() {}
+    open fun postStart() {}
 }
 
 interface TimerBase {
@@ -436,6 +439,18 @@ class NotesLoggingController(val fragment: BaseFragment, childId: Int) : Logging
     val noteEditor = bindings.noteEditor
 
     init {
+        try {
+            noteEditor.setOnFocusChangeListener { view, hasFocus ->
+                val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
+                when (hasFocus) {
+                    true -> imm?.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT)
+                    false -> imm?.hideSoftInputFromWindow(view.windowToken, InputMethodManager.HIDE_IMPLICIT_ONLY)
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+
         noteEditor.addTextChangedListener {
             updateVisuals()
         }
@@ -473,6 +488,11 @@ class NotesLoggingController(val fragment: BaseFragment, childId: Int) : Logging
         } else {
             View.GONE
         }
+    }
+
+    override fun postStart() {
+        super.postStart()
+        noteEditor.requestFocus()
     }
 }
 
@@ -962,6 +982,7 @@ class LoggingButtonController(
                 }
             }
         }
+        controller.postStart()
     }
 
     private suspend fun stopTimerFromSwitch(


### PR DESCRIPTION
And remove the keyboard again when the note is either saved, or cancelled.

----

I noticed that when I want to enter a note, I have to tap the input-field to get the keyboard to open. I'd like the convenience that you can directly start typing a note once you toggle the notes-button.