### PR TITLE
Dynamically update feed-timer icon based on user input

### DIFF
--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/Constants.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/Constants.kt
@@ -1,6 +1,14 @@
 package eu.pkgsoftware.babybuddywidgets
 
 import androidx.annotation.ColorRes
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -8,6 +16,8 @@ object Constants {
     @JvmField
     val SERVER_DATE_FORMAT = SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss z", Locale.ENGLISH)
 
+    @JsonSerialize(using = FeedingTypeEnum.FeedingTypeEnumSerializer::class)
+    @JsonDeserialize(using = FeedingTypeEnum.FeedingTypeEnumDeserializer::class)
     enum class FeedingTypeEnum(@JvmField var value: Int, @JvmField var post_name: String) {
         BREAST_MILK(0, "breast milk"),
         FORMULA(1, "formula"),
@@ -16,17 +26,25 @@ object Constants {
 
         companion object {
             @JvmStatic
-            fun byValue(value: Int): FeedingTypeEnum {
-                return FeedingTypeEnum.values().first { it.value == value }
+            fun byPostName(name: String): FeedingTypeEnum {
+                return FeedingTypeEnum.entries.first { it.post_name == name }
+            }
+        }
+        class FeedingTypeEnumSerializer : JsonSerializer<FeedingTypeEnum>() {
+            override fun serialize(value: FeedingTypeEnum?, gen: JsonGenerator?, serializers: SerializerProvider?) {
+                gen?.writeString(value?.post_name)
             }
 
-            @JvmStatic
-            fun byPostName(name: String): FeedingTypeEnum {
-                return FeedingTypeEnum.values().first { it.post_name == name }
-            }
+        }
+        class FeedingTypeEnumDeserializer : JsonDeserializer<FeedingTypeEnum>() {
+            override fun deserialize(parser: JsonParser?, ctxt: DeserializationContext?): FeedingTypeEnum? =
+                parser?.text?.let { FeedingTypeEnum.byPostName(it) }
+
         }
     }
 
+    @JsonSerialize(using = FeedingMethodEnum.FeedingMethodEnumSerializer::class)
+    @JsonDeserialize(using = FeedingMethodEnum.FeedingMethodEnumDeserializer::class)
     enum class FeedingMethodEnum(@JvmField var value: Int, @JvmField var post_name: String) {
         BOTTLE(0, "bottle"),
         LEFT_BREAST(1, "left breast"),
@@ -45,6 +63,17 @@ object Constants {
             fun byPostName(name: String): FeedingMethodEnum {
                 return FeedingMethodEnum.values().first { it.post_name == name }
             }
+        }
+        class FeedingMethodEnumSerializer : JsonSerializer<FeedingMethodEnum>() {
+            override fun serialize(value: FeedingMethodEnum?, gen: JsonGenerator?, serializers: SerializerProvider?) {
+                gen?.writeString(value?.post_name)
+            }
+
+        }
+        class FeedingMethodEnumDeserializer : JsonDeserializer<FeedingMethodEnum>() {
+            override fun deserialize(parser: JsonParser?, ctxt: DeserializationContext?): FeedingMethodEnum? =
+                parser?.text?.let { FeedingMethodEnum.byPostName(it) }
+
         }
     }
 

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/history/TimelineEntry.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/history/TimelineEntry.kt
@@ -215,19 +215,22 @@ class TimelineEntry(private val fragment: BaseFragment, private var _entry: Time
         binding.feedingBreastRightImage.visibility = View.GONE
         binding.feedingBottleImage.visibility = View.GONE
         binding.solidFoodImage.visibility = View.GONE
-        when (FeedingTypeEnum.byPostName(feeding.feedingType)) {
+        when (feeding.feedingType) {
             FeedingTypeEnum.BREAST_MILK -> {
-                val feedingMethod = FeedingMethodEnum.byPostName(
-                    feeding.feedingMethod
-                )
-                if (feedingMethod.value == 1) {
-                    binding.feedingBreastLeftImage.visibility = View.VISIBLE
-                } else if (feedingMethod.value == 2) {
-                    binding.feedingBreastRightImage.visibility = View.VISIBLE
-                } else if (feedingMethod.value == 3) {
-                    binding.feedingBreastImage.visibility = View.VISIBLE
-                } else {
-                    binding.feedingBottleImage.visibility = View.VISIBLE
+                val feedingMethod = feeding.feedingMethod
+
+                when (feedingMethod) {
+                    FeedingMethodEnum.LEFT_BREAST ->
+                        binding.feedingBreastLeftImage.visibility = View.VISIBLE
+                    FeedingMethodEnum.RIGHT_BREAST ->
+                        binding.feedingBreastRightImage.visibility = View.VISIBLE
+                    FeedingMethodEnum.BOTH_BREASTS ->
+                        binding.feedingBreastImage.visibility = View.VISIBLE
+
+                    FeedingMethodEnum.BOTTLE,
+                    FeedingMethodEnum.PARENT_FED,
+                    FeedingMethodEnum.SELF_FED ->
+                        binding.feedingBottleImage.visibility = View.VISIBLE
                 }
             }
 

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/networking/babybuddy/models/TimeEntries.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/networking/babybuddy/models/TimeEntries.kt
@@ -7,6 +7,9 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSetter
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import eu.pkgsoftware.babybuddywidgets.Constants
+import eu.pkgsoftware.babybuddywidgets.Constants.FeedingMethodEnum
+import eu.pkgsoftware.babybuddywidgets.Constants.FeedingTypeEnum
 import eu.pkgsoftware.babybuddywidgets.networking.BabyBuddyClient.ACTIVITIES
 import eu.pkgsoftware.babybuddywidgets.networking.BabyBuddyClient.EVENTS
 import eu.pkgsoftware.babybuddywidgets.DateTimeDeserializer
@@ -97,8 +100,8 @@ data class FeedingEntry(
     override val end: Date,
 
     @JsonSetter("notes") val _notes: String?,
-    @JsonProperty("type", required = true) val feedingType: String,
-    @JsonProperty("method", required = true) val feedingMethod: String,
+    @JsonProperty("type", required = true) val feedingType: FeedingTypeEnum,
+    @JsonProperty("method", required = true) val feedingMethod: FeedingMethodEnum,
     @JsonProperty("amount", required = true) val amount: Double?,
 ) : TimeEntry {
     override @JsonIgnore val appType: String = ACTIVITIES.FEEDING

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
@@ -676,7 +676,7 @@ class FeedingLoggingController(
                 end = maxDate(timer.start, nowServer()),
                 feedingType = selectedType!!,
                 feedingMethod = selectedMethod!!,
-                amount = feedingBinding.amountNumberPicker.value?.toDouble(),
+                amount = feedingBinding.amountNumberPicker.value,
                 _notes = feedingBinding.noteEditor.text.toString()
             )
         )

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
@@ -658,12 +658,42 @@ class FeedingLoggingController(
             feedingBinding.feedingMethodButtons.visibility = View.GONE
             feedingBinding.feedingMethodSpinner.visibility = View.VISIBLE
         }
+        feedingBinding.feedingIconImage.setImageResource(
+            feedingImageResourceFor(selectedType, selectedMethod)
+        )
 
         if (feedingBinding.feedingTypeSpinner.isVisible && feedingBinding.feedingMethodSpinner.isVisible) {
             saveButton.visibility = View.VISIBLE
         } else {
             saveButton.visibility = View.GONE
         }
+    }
+    fun feedingImageResourceFor(
+        selectedType: FeedingTypeEnum?,
+        selectedMethod: FeedingMethodEnum?,
+    ) = when (selectedType) {
+        FeedingTypeEnum.BREAST_MILK -> {
+            when (selectedMethod) {
+                FeedingMethodEnum.LEFT_BREAST -> R.drawable.pkg_breast_left
+                FeedingMethodEnum.RIGHT_BREAST -> R.drawable.pkg_breast_right
+
+
+                FeedingMethodEnum.BOTH_BREASTS,
+                null -> R.drawable.pkg_breast
+
+                FeedingMethodEnum.BOTTLE,
+                FeedingMethodEnum.PARENT_FED,
+                FeedingMethodEnum.SELF_FED,
+                    -> R.drawable.pkg_bottle
+            }
+        }
+
+        FeedingTypeEnum.SOLID_FOOD -> R.drawable.pkg_solid_food
+
+        FeedingTypeEnum.FORMULA,
+        FeedingTypeEnum.FORTIFIED_BREAST_MILK,
+        null,
+            -> R.drawable.pkg_bottle
     }
 
     override suspend fun createEntry(timer: Timer): TimeEntry {

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/timers/TimerControllersV2.kt
@@ -518,8 +518,8 @@ class TummyTimeLoggingController(
 data class FeedingRecord(
     @JsonProperty("amount") val amount: Double?,
     @JsonProperty("note") val note: String,
-    @JsonProperty("feeding_type") val feedingType: String?,
-    @JsonProperty("feeding_method") val feedingMethod: String?,
+    @JsonProperty("feeding_type") val feedingType: FeedingTypeEnum?,
+    @JsonProperty("feeding_method") val feedingMethod: FeedingMethodEnum?,
 )
 
 class FeedingLoggingController(
@@ -535,19 +535,19 @@ class FeedingLoggingController(
     override val controlsView: View = feedingBinding.root
 
     private var assignedMethodButtons: List<FeedingMethodEnum> = emptyList()
-    private var selectedType: String? = null
-    private var selectedMethod: String? = null
+    private var selectedType: FeedingTypeEnum? = null
+    private var selectedMethod: FeedingMethodEnum? = null
 
     override fun postInit() {
         super.postInit()
 
         populateButtonList(
-            fragment.resources.getTextArray(R.array.feedingTypes),
-            feedingBinding.feedingTypeButtons,
-            feedingBinding.feedingTypeSpinner,
-            object : ButtonListCallback {
+            textArray = fragment.resources.getTextArray(R.array.feedingTypes),
+            buttons = feedingBinding.feedingTypeButtons,
+            spinner = feedingBinding.feedingTypeSpinner,
+            callback = object : ButtonListCallback {
                 override fun onSelectionChanged(i: Int) {
-                    selectedType = FeedingTypeEnumValues[i]!!.post_name
+                    selectedType = FeedingTypeEnumValues[i]!!
                     selectedMethod = null
                     setupFeedingMethodButtons(FeedingTypeEnumValues[i]!!)
                     feedingBinding.feedingMethodButtons.visibility = View.VISIBLE
@@ -564,7 +564,7 @@ class FeedingLoggingController(
                     position: Int,
                     id: Long
                 ) {
-                    val newType = FeedingTypeEnumValues[position]!!.post_name
+                    val newType = FeedingTypeEnumValues[position]!!
                     if (newType == selectedType) return
                     selectedType = newType
                     selectedMethod = null
@@ -591,11 +591,11 @@ class FeedingLoggingController(
 
             it.feedingType?.let {
                 try {
-                    feedingBinding.feedingTypeSpinner.setSelection(FeedingTypeEnum.byPostName(it).value)
+                    feedingBinding.feedingTypeSpinner.setSelection(it.value)
                     selectedType = it
                     feedingBinding.feedingTypeButtons.visibility = View.GONE
                     feedingBinding.feedingTypeSpinner.visibility = View.VISIBLE
-                    setupFeedingMethodButtons(FeedingTypeEnum.byPostName(it))
+                    setupFeedingMethodButtons(it)
                 }
                 catch (_: NoSuchElementException) {
                 }
@@ -603,7 +603,7 @@ class FeedingLoggingController(
             it.feedingMethod?.let {
                 if (selectedType != null) {
                     try {
-                        assignedMethodButtons.indexOf(FeedingMethodEnum.byPostName(it)).let {
+                        assignedMethodButtons.indexOf(it).let {
                             feedingBinding.feedingMethodSpinner.setSelection(it)
                         }
                         selectedMethod = it
@@ -647,7 +647,7 @@ class FeedingLoggingController(
             feedingBinding.feedingMethodButtons.visibility = View.GONE
             feedingBinding.feedingMethodSpinner.visibility = View.GONE
         } else if (selectedMethod == null) {
-            setupFeedingMethodButtons(FeedingTypeEnum.byPostName(selectedType))
+            setupFeedingMethodButtons(selectedType)
             feedingBinding.feedingTypeButtons.visibility = View.GONE
             feedingBinding.feedingTypeSpinner.visibility = View.VISIBLE
             feedingBinding.feedingMethodButtons.visibility = View.VISIBLE
@@ -751,7 +751,7 @@ class FeedingLoggingController(
             feedingBinding.feedingMethodSpinner,
             object : ButtonListCallback {
                 override fun onSelectionChanged(i: Int) {
-                    selectedMethod = assignedMethodButtons[i].post_name
+                    selectedMethod = assignedMethodButtons[i]
                     updateVisuals()
                 }
             }
@@ -764,7 +764,7 @@ class FeedingLoggingController(
                     position: Int,
                     id: Long
                 ) {
-                    selectedMethod = assignedMethodButtons[position].post_name
+                    selectedMethod = assignedMethodButtons[position]
                     updateVisuals()
                 }
 

--- a/app/src/main/res/layout/feeding_logging_entry.xml
+++ b/app/src/main/res/layout/feeding_logging_entry.xml
@@ -124,7 +124,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:layout_marginTop="16dp"
-            android:text="Amount"
+            android:text="@string/feeding_amount_title"
             android:textAppearance="@android:style/TextAppearance.DeviceDefault.Widget.TextView.SpinnerItem"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/feeding_logging_entry.xml
+++ b/app/src/main/res/layout/feeding_logging_entry.xml
@@ -20,6 +20,7 @@
         app:layout_constraintTop_toTopOf="parent">
 
         <ImageView
+            android:id="@+id/feedingIconImage"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:scaleType="fitCenter"

--- a/app/src/main/res/layout/feeding_logging_entry.xml
+++ b/app/src/main/res/layout/feeding_logging_entry.xml
@@ -7,7 +7,7 @@
     android:orientation="horizontal">
 
     <FrameLayout
-        android:id="@+id/sleepIcon"
+        android:id="@+id/feedingIcon"
         android:layout_width="48dp"
         android:layout_height="0dp"
         android:background="@color/feeding_enabled"
@@ -46,7 +46,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/sleepIcon"
+        app:layout_constraintStart_toEndOf="@+id/feedingIcon"
         app:layout_constraintTop_toTopOf="parent">
 
         <EditText

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -15,6 +15,7 @@
     <string name="activity_singular_weight">Gewicht</string>
     <string name="activity_singular_height">Größe</string>
     <string name="activity_singular_head_circumference">Kopfumfang</string>
+    <string name="feeding_amount_title">Menge</string>
     <string name="store_feeding_amount_string">Menge: {amount}</string>
     <string name="store_feeding_amount_none">Nichts</string>
     <string name="tutorial_suggest_visit_help">Um loszulegen, schauen Sie sich die Hilfe im Hauptmenü an.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -190,6 +190,7 @@
     <string name="send_message_back_button">Terug</string>
     <string name="send_message_failed_message">Bericht kon niet worden verstuurd</string>
     <string name="send_message_sent_message">Bericht verstuurd naar ontwikkelaar</string>
+    <string name="feeding_amount_title">Volume</string>
     <string name="store_feeding_amount_string">Hoeveelheid: {quantity}</string>
     <string name="store_feeding_amount_none">Geen</string>
     <string name="activity_store_failure_server_error_general">Kon activiteit niet opslaan.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="activity_singular_head_circumference">head circumference</string>
 
     <!-- Feeding store messages -->
+    <string name="feeding_amount_title">Amount</string>
     <string name="store_feeding_amount_string">Amount: {quantity}</string>
     <string name="store_feeding_amount_none">None</string>
 


### PR DESCRIPTION
I noticed the timeline had nice icons indicating the feeding type & method. I like to see at a glance what a timeline entry is about. I thought it would be neat to also have the same for the timer itself, since I often fill in the details of the timer, but my partner will stop the timer on their phone. The app remembers my previous setting, so it would be "stuck" on the previous entry. This way, it is a tiny bit easier to see what method is selected.

This PR also has a few extra commits that are not strictly part of the change itself, but I employed a bit of the scouting rule and cleaned up files I touched.

 - Use/store enum value over string representation
 - Remove unneeded conversion to Double
 - Fix id of resources in `feeding_logging_entry.xml` to be `feeding` instead of `sleep`
 - Add translation for Amount in context of feeding fragment

If you'd rather see these as separate PR's I'll happily open new PR'.s