### PR TITLE
Fix delayed login when switching from wifi to data

### DIFF
--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/login/GrabAppToken.java
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/login/GrabAppToken.java
@@ -122,6 +122,8 @@ public class GrabAppToken extends StreamReader {
 
     private HttpURLConnection doQuery(String path) throws IOException {
         HttpURLConnection con = (HttpURLConnection) subPath(path).openConnection();
+        con.setConnectTimeout(5000); // 5 seconds to connect
+        con.setReadTimeout(10000);   // 10 seconds between reads
         for (Map.Entry<String, String> item : headers.entrySet()) {
             con.setRequestProperty(item.getKey(), item.getValue());
         }

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/login/GrabAppToken.java
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/login/GrabAppToken.java
@@ -122,8 +122,8 @@ public class GrabAppToken extends StreamReader {
 
     private HttpURLConnection doQuery(String path) throws IOException {
         HttpURLConnection con = (HttpURLConnection) subPath(path).openConnection();
-        con.setConnectTimeout(5000); // 5 seconds to connect
-        con.setReadTimeout(10000);   // 10 seconds between reads
+        con.setConnectTimeout(2000); // 2 seconds to connect
+        con.setReadTimeout(5000);   // 5  seconds between reads
         for (Map.Entry<String, String> item : headers.entrySet()) {
             con.setRequestProperty(item.getKey(), item.getValue());
         }

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/networking/BabyBuddyClient.java
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/networking/BabyBuddyClient.java
@@ -433,6 +433,8 @@ public class BabyBuddyClient extends StreamReader {
 
     private HttpURLConnection doQuery(String path) throws IOException {
         HttpURLConnection con = (HttpURLConnection) pathToUrl(path).openConnection();
+        con.setConnectTimeout(2000); // 2 seconds to connect
+        con.setReadTimeout(5000);   // 5  seconds between reads
         String token = credStore.getAppToken();
         con.setRequestProperty("Authorization", "Token " + token);
 

--- a/app/src/main/java/eu/pkgsoftware/babybuddywidgets/networking/StreamReader.java
+++ b/app/src/main/java/eu/pkgsoftware/babybuddywidgets/networking/StreamReader.java
@@ -19,18 +19,14 @@ public class StreamReader {
     @NonNull
     public static String loadHttpData(InputStream in) throws IOException {
         byte[] buffer = new byte[1000000];
-
         int offset = 0;
-        while (true) {
-            if (buffer.length - offset <= 0) {
-                break;
+        int len;
+        do {
+            len = in.read(buffer, offset, buffer.length - offset);
+            if (len > 0) {
+                offset += len;
             }
-            int len = in.read(buffer, offset, buffer.length - offset);
-            if (len <= 0) {
-                break;
-            }
-            offset += len;
-        }
+        } while (len > 0 && offset < buffer.length);
 
         String html;
         if (offset <= 0) {


### PR DESCRIPTION
In a dual SIM environment, when wifi is no longer connected, I'm seeing long delays (3-5 mins) establishing connection to the server.

Suspect timeouts too high, or android trying wrong data connection, or some combination of the two.

In my case I have a physical SIM with no data plan (so data never works), and an eSIM with data connection.

Symptoms appear like the connection to server is attempted over wrong data connection. This is evidenced by the fact my server doesn't receive the login attempt for minutes after the client attempts to login...

~~Further, I was able to mitigate the issue by disabling my physical sim (forcing only one data connection to try). But this is not a workable solution as I do need that sim active for calls and texts.~~ I have not been able to verify that workaround works consistently or at all.