### PR TITLE
Add missing German translations

### DIFF
--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Resources>
+<resources>
     <array name="timerTypeNames">
         <item>Mahlzeit</item>
         <item>Schlaf</item>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -1,5 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<Resources>
+    <array name="timerTypeNames">
+        <item>Mahlzeit</item>
+        <item>Schlaf</item>
+        <item>Bauchlage</item>
+        <item>Abpumpen</item>
+    </array>
+    <array name="feedingTypes">
+        <item>Brustmilch</item>
+        <item>Säuglingsnahrung</item>
+        <item>Angereicherte Brustmilch</item>
+        <item>Feste Nahrung</item>
+    </array>
+    <array name="feedingMethods">
+        <item>Fläschchen</item>
+        <item>Linke Brust</item>
+        <item>Rechte Brust</item>
+        <item>Beide Brüste</item>
+        <item>Durch Eltern gefüttert</item>
+        <item>Selber gefüttert</item>
+    </array>
+    <array name="solidDiaperColors">
+        <item>Schwarz</item>
+        <item>Braun</item>
+        <item>Grün</item>
+        <item>Gelb</item>
+    </array>
     <string name="app_name">Baby Buddy</string>
     <string name="about_text">Diese Android-App ist Open-Source-Software, die von &lt;a href=\'http://www.craftware.info\'&gt;Paul Konstantin Gerke&lt;/a&gt; erstellt wurde und unter der MIT-Lizenz (siehe unten) lizenziert ist. Der Quellcode der App ist verfügbar via &lt;a href=\'https://github.com/babybuddy/babybuddy-for-android/\'&gt;https://github.com/babybuddy/babybuddy-for-android/&lt;/a&gt;. Die App verwendet Mediendateien von Dritten deren Verwendung durch die unten genannten Lizenzen geregelt ist.</string>
     <string name="about_external_media_resources_title">Medien von Drittanbietern</string>


### PR DESCRIPTION
Add missing German translations for feeding types, feeding methods, timer type names and solid diaper colors. These <array> resources exist in values/ and values-nl/ but were absent from values-de-rDE/, so German users saw the English fallback (e.g. "Breast milk"). Wording matches the official German server translation in babybuddy/locale/de/LC_MESSAGES/django.po for consistency between app and web UI.